### PR TITLE
cost history 기본값 180일로 수정, async 제거.

### DIFF
--- a/server/app/client.py
+++ b/server/app/client.py
@@ -68,7 +68,7 @@ class KloudClient:
         await self._update_resource_dict()
         return self._resources
 
-    async def get_cost_history(self, time_period: dict, granularity: str) -> dict:
+    def get_cost_history(self, time_period: dict, granularity: str) -> dict:
         res = self._ce_client.get_cost_and_usage(TimePeriod=time_period,
                                                  Granularity=granularity,
                                                  Metrics=['UnblendedCost', 'UsageQuantity'],
@@ -76,13 +76,13 @@ class KloudClient:
                                                           {'Type': 'DIMENSION', 'Key': 'USAGE_TYPE'}])
         return res
 
-    async def get_default_cost_history(self) -> dict:
+    def get_default_cost_history(self) -> dict:
         tp = {
-            'Start': str(datetime.date(datetime.now() - timedelta(days=90))),
+            'Start': str(datetime.date(datetime.now() - timedelta(days=180))),
             'End': str(datetime.date(datetime.now()))
         }
         granularity = 'DAILY'
-        return await self.get_cost_history(time_period=tp, granularity=granularity)
+        return self.get_cost_history(time_period=tp, granularity=granularity)
 
     async def get_infra_tree(self) -> dict:
         await self.get_current_infra_dict()

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -105,7 +105,7 @@ async def logout(user_id=Depends(get_user_id)):  # todo token revoke 목록
 
 
 @app.post("/cost/trend/cos-sim")
-async def pattern_finder(user_client=Depends(get_user_client)):
+def pattern_finder(user_client=Depends(get_user_client)):
     data = user_client.get_default_cost_history()
     p = PatternFinder(data)
     # 날짜는 수정이 가능함 원하는 날짜가 들어오게 만들면 될 듯

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -106,7 +106,7 @@ async def logout(user_id=Depends(get_user_id)):  # todo token revoke 목록
 
 @app.post("/cost/trend/cos-sim")
 async def pattern_finder(user_client=Depends(get_user_client)):
-    data = await user_client.get_default_cost_history()
+    data = user_client.get_default_cost_history()
     p = PatternFinder(data)
     # 날짜는 수정이 가능함 원하는 날짜가 들어오게 만들면 될 듯
     result = p.search('2022-02-02',"2022-03-20",threshold = 0.5)

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -85,8 +85,8 @@ async def infra_info(user_client=Depends(get_user_client)):
 
 
 @app.post("/cost/history/default")
-async def cost_history_default(user_client=Depends(get_user_client)):
-    return await user_client.get_default_cost_history()
+def cost_history_default(user_client=Depends(get_user_client)):
+    return user_client.get_default_cost_history()
 
 
 @app.post("/infra/tree")


### PR DESCRIPTION
180일로 수정하니 응답시간이 상당히 늘어났습니다. 

일단 async 수정한 부분은 처리를 했으나, 제대로 작동하는지 확인이 필요합니다. 